### PR TITLE
add tsit54 to ode integrators

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ These are the implemented ODE integrators:
 - `Ralston4` - Ralston's 4th order fixed timestep method.
 - `Kutta4` - Kutta's 4th order fixed timestep method.
 - `RK4` - The standard 4th order, fixed timestep method we all know and love.
+- `Tsit54` - Tsitouras adaptive 5th order method.
 
 
 

--- a/src/numericalnim/ode.nim
+++ b/src/numericalnim/ode.nim
@@ -14,7 +14,7 @@ const fixedODE* = @["heun2", "ralston2", "kutta3", "heun3", "ralston3", "ssprk3"
 const adaptiveODE* = @["rk21", "bs32", "dopri54", "tsit54"]
 const allODE* = fixedODE.concat(adaptiveODE)
 
-proc newODEoptions*(dt = 1e-4, tol = 1e-4, dtMax = 1e-2, dtMin = 1e-8,
+proc newODEoptions*(dt = 1e-4, tol = 1e-4, dtMax = 1e-2, dtMin = 1e-4,
                     tStart = 0.0): ODEoptions =
     ## Create a new ODEoptions object.
     ##

--- a/src/numericalnim/ode.nim
+++ b/src/numericalnim/ode.nim
@@ -11,7 +11,7 @@ type
         tStart*: float
 
 const fixedODE* = @["heun2", "ralston2", "kutta3", "heun3", "ralston3", "ssprk3", "ralston4", "kutta4", "rk4"]
-const adaptiveODE* = @["rk21", "bs32", "dopri54"]
+const adaptiveODE* = @["rk21", "bs32", "dopri54", "tsit54"]
 const allODE* = fixedODE.concat(adaptiveODE)
 
 proc newODEoptions*(dt = 1e-4, tol = 1e-4, dtMax = 1e-2, dtMin = 1e-8,
@@ -257,6 +257,83 @@ proc DOPRI54_step[T](f: proc(t: float, y: T): T, t: float, y, FSAL: T, dt: float
     result = (yNew, k7, dt, error)
 
 
+proc TSIT54_step[T](f: proc(t: float, y: T): T, t: float, y, FSAL: T, dt: float,
+                     options: ODEoptions): (T, T, float, float) =
+    ## Take a single timestep using TSIT54. Only for internal use.
+    const
+        c2 = 0.161
+        c3 = 0.327
+        c4 = 0.9
+        c5 = 0.9800255409045097
+        c6 = 1.0
+        c7 = 1.0
+        a21 = 0.161
+        a31 = -0.008480655492356989
+        a32 = 0.335480655492357
+        a41 = 2.8971530571054935
+        a42 = -6.359448489975075
+        a43 = 4.3622954328695815
+        a51 = 5.325864828439257
+        a52 = -11.748883564062828
+        a53 = 7.4955393428898365
+        a54 = -0.09249506636175525
+        a61 = 5.86145544294642
+        a62 = -12.92096931784711
+        a63 = 8.159367898576159
+        a64 = -0.071584973281401
+        a65 = -0.028269050394068383
+        a71 = 0.09646076681806523
+        a72 = 0.01
+        a73 = 0.4798896504144996
+        a74 = 1.379008574103742
+        a75 = -3.290069515436081
+        a76 = 2.324710524099774
+        # Fifth order
+        b1 = a71
+        b2 = a72
+        b3 = a73
+        b4 = a74
+        b5 = a75
+        b6 = a76
+        # Fourth order
+        bHat1 = -0.001780011052226
+        bHat2 = -0.000816434459657
+        bHat3 = 0.007880878010262
+        bHat4 = -0.144711007173263
+        bHat5 = 0.582357165452555
+        bHat6 = -0.458082105929187
+        bHat7 = 1.0/66.0
+    let tol = options.tol
+    let dtMax = options.dtMax
+    let dtMin = options.dtMin
+    var k1, k2, k3, k4, k5, k6, k7: T
+    var yNew, yLow: T
+    var error: float
+    var limitCounter = 0
+    var dt = dt
+    while true and limitCounter < 2:
+        k1 = FSAL
+        k2 = f(t + dt*c2, y + dt * (a21 * k1))
+        k3 = f(t + dt*c3, y + dt * (a31 * k1 + a32 * k2))
+        k4 = f(t + dt*c4, y + dt * (a41 * k1 + a42 * k2 + a43 * k3))
+        k5 = f(t + dt*c5, y + dt * (a51 * k1 + a52 * k2 + a53 * k3 + a54 * k4))
+        k6 = f(t + dt*c6, y + dt * (a61 * k1 + a62 * k2 + a63 * k3 + a64 * k4 + a65 * k5))
+        k7 = f(t + dt*c7, y + dt * (a71 * k1 + a72 * k2 + a73 * k3 + a74 * k4 + a75 * k5 + a76 * k6))
+
+        yNew = y + dt * (b1 * k1 + b2 * k2 + b3 * k3 + b4 * k4 + b5 * k5 + b6 * k6)
+        yLow = y + dt * (bHat1 * k1 + bHat2 * k2 + bHat3 * k3 + bHat4 * k4 + bHat5 * k5 + bHat6 * k6 + bHat7 * k7)
+        error = calcError(yNew, yLow)
+        if error <= tol:
+            break
+        dt = 0.9 * dt * pow(tol/error, 1/5)
+        if abs(dt) < dtMin:
+            dt = dtMin
+            limitCounter += 1
+        elif dtMax < abs(dt):
+            dt = dtMax
+    result = (yNew, k7, dt, error)
+
+
 proc ODESolver[T](f: proc(t: float, y: T): T, y0: T, tspan: openArray[float],
                   options: ODEoptions = DEFAULT_ODEoptions,
                   integrator: proc(f: proc(t: float, y: T): T,
@@ -429,5 +506,8 @@ proc solveODE*[T](f: proc(t: float, y: T): T, y0: T, tspan: openArray[float],
         of "kutta4":
             return ODESolver(f, y0, tspan.sorted(), options, KUTTA4_step,
                                 useFSAL = false, order = 4.0, adaptive = false)
+        of "tsit54":
+            return ODESolver(f, y0, tspan.sorted(), options, TSIT54_step,
+                             useFSAL = true, order = 5.0, adaptive = true)
         else:
             raise newException(ValueError, &"{integrator} is not a valid integrator")

--- a/src/numericalnim/ode.nim
+++ b/src/numericalnim/ode.nim
@@ -322,7 +322,7 @@ proc TSIT54_step[T](f: proc(t: float, y: T): T, t: float, y, FSAL: T, dt: float,
 
         yNew = y + dt * (b1 * k1 + b2 * k2 + b3 * k3 + b4 * k4 + b5 * k5 + b6 * k6)
         yLow = y + dt * (bHat1 * k1 + bHat2 * k2 + bHat3 * k3 + bHat4 * k4 + bHat5 * k5 + bHat6 * k6 + bHat7 * k7)
-        error = calcError(yNew, yLow)
+        error = calcError(y, yLow)
         if error <= tol:
             break
         dt = 0.9 * dt * pow(tol/error, 1/5)

--- a/src/numericalnim/ode.nim
+++ b/src/numericalnim/ode.nim
@@ -22,7 +22,7 @@ proc newODEoptions*(dt = 1e-4, tol = 1e-4, dtMax = 1e-2, dtMin = 1e-8,
     ##   - dt: The time step to use in fixed timestep integrators.
     ##   - tol: The error tolerance to use in adaptive timestep integrators.
     ##   - dtMax: The maximum timestep allowed in adaptive timestep integrators.
-    ##   - dtMax: The maximum timestep allowed in adaptive timestep integrators.
+    ##   - dtMin: The minimum timestep allowed in adaptive timestep integrators.
     ##   - tStart: The time to start the ODE-solver at. The time the initial
     ##     conditions are supplied at.
     ##

--- a/tests/test_ode.nim
+++ b/tests/test_ode.nim
@@ -111,6 +111,18 @@ test "BS32, default":
     for i, val in y:
         check isClose(val, correctY[i], tol=1e-6)
 
+test "Tsit54, default":
+    let (t, y) = solveODE(f, y0, tspan, integrator="tsit54")
+    check t == tspan
+    for i, val in y:
+        check isClose(val, correctY[i], tol=1e-4)
+
+test "Tsit54, tol = 1e-8":
+    let (t, y) = solveODE(f, y0, tspan, integrator="tsit54", options=newODEoptions(dt=1e-6))
+    check t == tspan
+    for i, val in y:
+        check isClose(val, correctY[i], tol=1e-8)
+
 test "DOPRI54 Vector, default":
     let (t, y) = solveODE(fVector, y0Vector, tspan, integrator="dopri54")
     check t == tspan
@@ -147,6 +159,18 @@ test "Heun2 Vector, dt = 1e-2":
     for i, val in y:
         check isClose(val, correctYVector[i], tol=1e-5)
 
+test "Tsit54 Vector, default":
+    let (t, y) = solveODE(fVector, y0Vector, tspan, integrator="tsit54")
+    check t == tspan
+    for i, val in y:
+        check isClose(val, correctYVector[i], tol=1e-4)
+
+test "Tsit54 Vector, dt = 1e-2":
+    let (t, y) = solveODE(fVector, y0Vector, tspan, integrator="tsit54", options=newODEoptions(dt=1e-2))
+    check t == tspan
+    for i, val in y:
+        check isClose(val, correctYVector[i], tol=1e-8)
+
 test "DOPRI54 Tensor, default":
     let (t, y) = solveODE(fTensor, y0Tensor, tspan, integrator="dopri54")
     check t == tspan
@@ -182,3 +206,15 @@ test "Heun2 Tensor, dt = 1e-2":
     check t == tspan
     for i, val in y:
         check isClose(val, correctYTensor[i], tol=1e-5)
+
+test "Tsit54 Tensor, default":
+    let (t, y) = solveODE(fTensor, y0Tensor, tspan, integrator="tsit54")
+    check t == tspan
+    for i, val in y:
+        check isClose(val, correctYTensor[i], tol=1e-4)
+
+test "Tsit54 Tensor, dt=1e-2":
+    let (t, y) = solveODE(fTensor, y0Tensor, tspan, integrator="tsit54", options=ooTensor)
+    check t == tspan
+    for i, val in y:
+        check isClose(val, correctYTensor[i], tol=1e-8)

--- a/tests/test_ode.nim
+++ b/tests/test_ode.nim
@@ -118,7 +118,7 @@ test "Tsit54, default":
         check isClose(val, correctY[i], tol=1e-4)
 
 test "Tsit54, tol = 1e-8":
-    let (t, y) = solveODE(f, y0, tspan, integrator="tsit54", options=newODEoptions(dt=1e-6))
+    let (t, y) = solveODE(f, y0, tspan, integrator="tsit54", options=oo)
     check t == tspan
     for i, val in y:
         check isClose(val, correctY[i], tol=1e-8)
@@ -166,7 +166,7 @@ test "Tsit54 Vector, default":
         check isClose(val, correctYVector[i], tol=1e-4)
 
 test "Tsit54 Vector, dt = 1e-2":
-    let (t, y) = solveODE(fVector, y0Vector, tspan, integrator="tsit54", options=newODEoptions(dt=1e-2))
+    let (t, y) = solveODE(fVector, y0Vector, tspan, integrator="tsit54", options=ooVector)
     check t == tspan
     for i, val in y:
         check isClose(val, correctYVector[i], tol=1e-8)


### PR DESCRIPTION
Hello and thank you for your great work creating this library!

I implemented Tsitouras 5th order method and added it to the list of integrators.
Informations about the method can be found at [Runge–Kutta pairs of order 5(4) satisfying only the first column simplifying assumption](https://dx.doi.org/10.1016/j.camwa.2011.06.002).

In the testsuite it becomes quiet slow for lower tolerances ( till 1e-7) and fails for <=1e-8.
For higher tolerances it works fine. However, using standard tolerances, it still passes the high tolerance test

Maybe I have missed something there? It would be great if you could take a look at it and help me fix it.
