### PR TITLE
DRY the code for adaptive integrators

### DIFF
--- a/src/numericalnim/ode.nim
+++ b/src/numericalnim/ode.nim
@@ -14,6 +14,18 @@ const fixedODE* = @["heun2", "ralston2", "kutta3", "heun3", "ralston3", "ssprk3"
 const adaptiveODE* = @["rk21", "bs32", "dopri54", "tsit54", "vern65"]
 const allODE* = fixedODE.concat(adaptiveODE)
 
+
+template commonAdaptiveMethodCode(e1, e2: float, order: int) =
+    error = calcError(e1, e2)
+    if error <= tol:
+        break
+    dt = 0.9 * dt * pow(tol/error, 1/order)
+    if abs(dt) < dtMin:
+        dt = dtMin
+        limitCounter += 1
+    elif dtMax < abs(dt):
+        dt = dtMax
+
 proc newODEoptions*(dt = 1e-4, tol = 1e-4, dtMax = 1e-2, dtMin = 1e-4,
                     tStart = 0.0): ODEoptions =
     ## Create a new ODEoptions object.
@@ -138,15 +150,7 @@ proc RK21_step[T](f: proc(t: float, y: T): T, t: float, y, FSAL: T, dt: float,
         
         yNew = y + dt * 0.5 * (k1 + k2)
         yLow = y + dt * k1
-        error = calcError(yNew, yLow)
-        if error <= tol:
-            break
-        dt = 0.9 * dt * pow(tol/error, 1/2)
-        if abs(dt) < dtMin:
-            dt = dtMin
-            limitCounter += 1
-        elif dtMax < abs(dt):
-            dt = dtMax
+        commonAdaptiveMethodCode(yNew, yLow, 2)
     result = (yNew, yNew, dt, error)
 
 proc BS32_step[T](f: proc(t: float, y: T): T, t: float, y, FSAL: T, dt: float,
@@ -168,15 +172,7 @@ proc BS32_step[T](f: proc(t: float, y: T): T, t: float, y, FSAL: T, dt: float,
         k4 = f(t + dt, yNew)
         
         yLow = y + dt * (7/24 * k1 + 1/4 * k2 + 1/3 * k3 + 1/8 * k4)
-        error = calcError(yNew, yLow)
-        if error <= tol:
-            break
-        dt = 0.9 * dt * pow(tol/error, 1/3)
-        if abs(dt) < dtMin:
-            dt = dtMin
-            limitCounter += 1
-        elif dtMax < abs(dt):
-            dt = dtMax
+        commonAdaptiveMethodCode(yNew, yLow, 3)
     result = (yNew, k4, dt, error)
 
 
@@ -245,15 +241,7 @@ proc DOPRI54_step[T](f: proc(t: float, y: T): T, t: float, y, FSAL: T, dt: float
 
         yNew = y + dt * (b1 * k1 + b2 * k2 + b3 * k3 + b4 * k4 + b5 * k5 + b6 * k6)
         yLow = y + dt * (bHat1 * k1 + bHat2 * k2 + bHat3 * k3 + bHat4 * k4 + bHat5 * k5 + bHat6 * k6 + bHat7 * k7)
-        error = calcError(yNew, yLow)
-        if error <= tol:
-            break
-        dt = 0.9 * dt * pow(tol/error, 1/5)
-        if abs(dt) < dtMin:
-            dt = dtMin
-            limitCounter += 1
-        elif dtMax < abs(dt):
-            dt = dtMax
+        commonAdaptiveMethodCode(yNew, yLow, 5)
     result = (yNew, k7, dt, error)
 
 proc TSIT54_step[T](f: proc(t: float, y: T): T, t: float, y, FSAL: T, dt: float,
@@ -321,15 +309,7 @@ proc TSIT54_step[T](f: proc(t: float, y: T): T, t: float, y, FSAL: T, dt: float,
 
         yNew = y + dt * (b1 * k1 + b2 * k2 + b3 * k3 + b4 * k4 + b5 * k5 + b6 * k6)
         yLow = y + dt * (bHat1 * k1 + bHat2 * k2 + bHat3 * k3 + bHat4 * k4 + bHat5 * k5 + bHat6 * k6 + bHat7 * k7)
-        error = calcError(y, yLow)
-        if error <= tol:
-            break
-        dt = 0.9 * dt * pow(tol/error, 1/5)
-        if abs(dt) < dtMin:
-            dt = dtMin
-            limitCounter += 1
-        elif dtMax < abs(dt):
-            dt = dtMax
+        commonAdaptiveMethodCode(y, yLow, 5)
     result = (yNew, k7, dt, error)
     
 
@@ -421,15 +401,7 @@ proc VERN65_step[T](f: proc(t: float, y: T): T, t: float, y, FSAL: T, dt: float,
 
         yNew = y + dt * (b1 * k1 + b2 * k2 + b3 * k3 + b4 * k4 + b5 * k5 + b6 * k6 + b7 * k7 + b8 * k8)
         yLow = y + dt * (bHat1 * k1 + bHat2 * k2 + bHat3 * k3 + bHat4 * k4 + bHat5 * k5 + bHat6 * k6 + bHat7 * k7 + bHat8 * k8 + bHat9 * k9)
-        error = calcError(yNew, yLow)
-        if error <= tol:
-            break
-        dt = 0.9 * dt * pow(tol/error, 1/5)
-        if abs(dt) < dtMin:
-            dt = dtMin
-            limitCounter += 1
-        elif dtMax < abs(dt):
-            dt = dtMax
+        commonAdaptiveMethodCode(yNew, yLow, 6)
     result = (yNew, k9, dt, error)
 
 

--- a/src/numericalnim/ode.nim
+++ b/src/numericalnim/ode.nim
@@ -15,11 +15,10 @@ const adaptiveODE* = @["rk21", "bs32", "dopri54", "tsit54", "vern65"]
 const allODE* = fixedODE.concat(adaptiveODE)
 
 
-template commonAdaptiveMethodCode(e1, e2: float, order: int, body: untyped) =
+template commonAdaptiveMethodCode(order: int, body: untyped) =
     while true and limitCounter < 2:
         body
 
-        error = calcError(e1, e2)
         if error <= tol:
             break
         dt = 0.9 * dt * pow(tol/error, 1/order)
@@ -147,7 +146,7 @@ proc RK21_step[T](f: proc(t: float, y: T): T, t: float, y, FSAL: T, dt: float,
     var error: float
     var limitCounter = 0
     var dt = dt
-    commonAdaptiveMethodCode(yNew, yLow, 2):
+    commonAdaptiveMethodCode(2):
         k1 = f(t, y)
         k2 = f(t + dt, y + dt * k1)
         
@@ -166,7 +165,7 @@ proc BS32_step[T](f: proc(t: float, y: T): T, t: float, y, FSAL: T, dt: float,
     var error: float
     var limitCounter = 0
     var dt = dt
-    commonAdaptiveMethodCode(yNew, yLow, 3):
+    commonAdaptiveMethodCode(3):
         k1 = f(t, y)
         k2 = f(t + 0.5 * dt, y + 0.5 * dt * k1)
         k3 = f(t + 0.75 * dt, y + 0.75 * dt * k2)
@@ -174,6 +173,7 @@ proc BS32_step[T](f: proc(t: float, y: T): T, t: float, y, FSAL: T, dt: float,
         k4 = f(t + dt, yNew)
         
         yLow = y + dt * (7/24 * k1 + 1/4 * k2 + 1/3 * k3 + 1/8 * k4)
+        error = calcError(yNew, yLow)
     result = (yNew, k4, dt, error)
 
 
@@ -231,7 +231,7 @@ proc DOPRI54_step[T](f: proc(t: float, y: T): T, t: float, y, FSAL: T, dt: float
     var error: float
     var limitCounter = 0
     var dt = dt
-    commonAdaptiveMethodCode(yNew, yLow, 5):
+    commonAdaptiveMethodCode(5):
         k1 = FSAL
         k2 = f(t + dt*c2, y + dt * (a21 * k1))
         k3 = f(t + dt*c3, y + dt * (a31 * k1 + a32 * k2))
@@ -242,6 +242,7 @@ proc DOPRI54_step[T](f: proc(t: float, y: T): T, t: float, y, FSAL: T, dt: float
 
         yNew = y + dt * (b1 * k1 + b2 * k2 + b3 * k3 + b4 * k4 + b5 * k5 + b6 * k6)
         yLow = y + dt * (bHat1 * k1 + bHat2 * k2 + bHat3 * k3 + bHat4 * k4 + bHat5 * k5 + bHat6 * k6 + bHat7 * k7)
+        error = calcError(yNew, yLow)
     result = (yNew, k7, dt, error)
 
 proc TSIT54_step[T](f: proc(t: float, y: T): T, t: float, y, FSAL: T, dt: float,
@@ -298,7 +299,7 @@ proc TSIT54_step[T](f: proc(t: float, y: T): T, t: float, y, FSAL: T, dt: float,
     var error: float
     var limitCounter = 0
     var dt = dt
-    commonAdaptiveMethodCode(y, yLow, 5):
+    commonAdaptiveMethodCode(5):
         k1 = FSAL
         k2 = f(t + dt*c2, y + dt * (a21 * k1))
         k3 = f(t + dt*c3, y + dt * (a31 * k1 + a32 * k2))
@@ -309,6 +310,7 @@ proc TSIT54_step[T](f: proc(t: float, y: T): T, t: float, y, FSAL: T, dt: float,
 
         yNew = y + dt * (b1 * k1 + b2 * k2 + b3 * k3 + b4 * k4 + b5 * k5 + b6 * k6)
         yLow = y + dt * (bHat1 * k1 + bHat2 * k2 + bHat3 * k3 + bHat4 * k4 + bHat5 * k5 + bHat6 * k6 + bHat7 * k7)
+        error = calcError(y, yLow)
     result = (yNew, k7, dt, error)
     
 
@@ -387,7 +389,7 @@ proc VERN65_step[T](f: proc(t: float, y: T): T, t: float, y, FSAL: T, dt: float,
     var error: float
     var limitCounter = 0
     var dt = dt
-    commonAdaptiveMethodCode(yNew, yLow, 6):
+    commonAdaptiveMethodCode(6):
         k1 = FSAL
         k2 = f(t + dt*c2, y + dt * (a21 * k1))
         k3 = f(t + dt*c3, y + dt * (a31 * k1 + a32 * k2))
@@ -400,6 +402,7 @@ proc VERN65_step[T](f: proc(t: float, y: T): T, t: float, y, FSAL: T, dt: float,
 
         yNew = y + dt * (b1 * k1 + b2 * k2 + b3 * k3 + b4 * k4 + b5 * k5 + b6 * k6 + b7 * k7 + b8 * k8)
         yLow = y + dt * (bHat1 * k1 + bHat2 * k2 + bHat3 * k3 + bHat4 * k4 + bHat5 * k5 + bHat6 * k6 + bHat7 * k7 + bHat8 * k8 + bHat9 * k9)
+        error = calcError(yNew, yLow)
     result = (yNew, k9, dt, error)
 
 


### PR DESCRIPTION
Hello,

I put some common code of the adaptive methods in a template so we don't have to repeat it for every new adaptive method.

Would that be useful or does it make the code more confusing? What is your opinion?
Also, maybe this could be done differently?