### PR TITLE
New error calc

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ If we `echo y1, y2` we see that both gives roughly the same answer.
 
 ```nim
 @[0.8187307530779675, 0.9048374180359479, 1.0, 1.105170918075657, 1.221402758160196]
-@[0.8187307530779828, 0.904837418035959, 1.0, 1.105170918075646, 1.221402758160169]
+@[0.8187307530779815, 0.9048374180359576, 1.0, 1.105170918075645, 1.221402758160169]
 ```
 
 The analytical solution to the ODE is y(t) = exp(0.1*t) so we can compare both methods and see if the error is different:
@@ -107,19 +107,19 @@ As we can see both methods gives a good numerical approximation of this simple O
 
 Now it's time to play with the parameters and NumericalNim makes it easy to handle them using a `ODEoptions` type that is passed to `solveODE`. Here are the defaults:
 ```nim
-let options = newODEoptions(dt = 1e-4, tol = 1e-4, dtMax = 1e-2, dtMin = 1e-8, tStart = 0.0)
+let options = newODEoptions(dt = 1e-4, relTol = 1e-4, dtMax = 1e-2, dtMin = 1e-8, tStart = 0.0)
 let (t, y) = solveODE(f, y0, tspan, options = options, integrator = "dopri54")
 ```
 - `dt` - the timestep used by the fixed timestep methods.
-- `tol` - the tolerance used by the adaptive methods.
+- `relTol` - the relative tolerance used by the adaptive methods.
 - `dtMax` - the maximum allowed dt the adaptive method is allowed to use.
 - `dtMin` - the smallest allowed dt the adaptive method is allowed to use.
 - `tStart` - the time that the initial values are provided at.
 
-If we lower `dt` to `1e-1` and `tol` to `1e-1` we should get a higher error than last time. Let's see!
+If we lower `dt` to `1e-1` and `relTol` to `1e-1` we should get a higher error than last time. Let's see!
 
 ```nim
-let options = newODEoptions(dt = 1e-4, tol = 1e-4, dtMax = 1e-2, dtMin = 1e-8, tStart = 0.0)
+let options = newODEoptions(dt = 1e-1, relTol = 1e-1, dtMax = 1e-2, dtMin = 1e-8, tStart = 0.0)
 let (t3, y3) = solveODE(f, y0, tspan, options = options, integrator = "rk4")
 let (t4, y4) = solveODE(f, y0, tspan, options, integrator="dopri54")
 
@@ -133,7 +133,7 @@ DOPRI54: 1.110223024625157e-015
 The error of `RK4` got a bit higher but not `DOPRI54`. If we increase `dtMax` to `1.0` we get the following:
 ```nim
 RK4: 2.018807343517892e-011
-DOPRI54: -4.620754889828049e-010
+DOPRI54: -3.126410241804933e-010
 ```
 Now the error is higher for `DOPRI54` as well.
 

--- a/src/numericalnim/ode.nim
+++ b/src/numericalnim/ode.nim
@@ -12,6 +12,7 @@ type
         relTol*: float
         scaleMax*: float
         scaleMin*: float
+    IntegratorProc*[T] = proc(f: proc(t: float, y: T): T, t: float, y, FSAL: T, dt: float, options: ODEoptions): (T, T, float, float)
 
 const fixedODE* = @["heun2", "ralston2", "kutta3", "heun3", "ralston3", "ssprk3", "ralston4", "kutta4", "rk4"]
 const adaptiveODE* = @["rk21", "bs32", "dopri54", "tsit54", "vern65"]
@@ -446,9 +447,7 @@ proc VERN65_step[T](f: proc(t: float, y: T): T, t: float, y, FSAL: T, dt: float,
 
 proc ODESolver[T](f: proc(t: float, y: T): T, y0: T, tspan: openArray[float],
                   options: ODEoptions = DEFAULT_ODEoptions,
-                  integrator: proc(f: proc(t: float, y: T): T,
-                                   t: float, y, FSAL: T,
-                                   dt: float, options: ODEoptions): (T, T, float, float),
+                  integrator: IntegratorProc[T],
                   useFSAL = false, order: float, adaptive = false): (seq[float], seq[T]) =
     ## Handles the ODE solving. Only for internal use.
     let t0 = options.tStart
@@ -580,46 +579,46 @@ proc solveODE*[T](f: proc(t: float, y: T): T, y0: T, tspan: openArray[float],
     ##   - A tuple containing a seq of t-values and a seq of y-values (t, y).
     case integrator.toLower():
         of "dopri54":
-            return ODESolver(f, y0, tspan.sorted(), options, DOPRI54_step,
+            return ODESolver(f, y0, tspan.sorted(), options, DOPRI54_step[T],
                              useFSAL = true, order = 5.0, adaptive = true)
         of "rk21":
-            return ODESolver(f, y0, tspan.sorted(), options, RK21_step ,
+            return ODESolver(f, y0, tspan.sorted(), options, RK21_step[T],
                                 useFSAL = false, order = 2.0, adaptive = true)
         of "bs32":
-            return ODESolver(f, y0, tspan.sorted(), options, BS32_step,
+            return ODESolver(f, y0, tspan.sorted(), options, BS32_step[T],
                                 useFSAL = true, order = 3.0, adaptive = true)
         of "rk4":
-            return ODESolver(f, y0, tspan.sorted(), options, RK4_step,
+            return ODESolver(f, y0, tspan.sorted(), options, RK4_step[T],
                              useFSAL = false, order = 4.0, adaptive = false)
         of "heun2":
-            return ODESolver(f, y0, tspan.sorted(), options, HEUN2_step,
+            return ODESolver(f, y0, tspan.sorted(), options, HEUN2_step[T],
                              useFSAL = false, order = 2.0, adaptive = false)
         of "ralston2":
-            return ODESolver(f, y0, tspan.sorted(), options, RALSTON2_step,
+            return ODESolver(f, y0, tspan.sorted(), options, RALSTON2_step[T],
                              useFSAL = false, order = 2.0, adaptive = false)
         of "kutta3":
-            return ODESolver(f, y0, tspan.sorted(), options, KUTTA3_step,
+            return ODESolver(f, y0, tspan.sorted(), options, KUTTA3_step[T],
                                 useFSAL = false, order = 3.0, adaptive = false)
         of "heun3":
-            return ODESolver(f, y0, tspan.sorted(), options, HEUN3_step,
+            return ODESolver(f, y0, tspan.sorted(), options, HEUN3_step[T],
                                 useFSAL = false, order = 3.0, adaptive = false)
         of "ralston3":
-            return ODESolver(f, y0, tspan.sorted(), options, RALSTON3_step,
+            return ODESolver(f, y0, tspan.sorted(), options, RALSTON3_step[T],
                                 useFSAL = false, order = 3.0, adaptive = false)
         of "ssprk3":
-            return ODESolver(f, y0, tspan.sorted(), options, SSPRK3_step,
+            return ODESolver(f, y0, tspan.sorted(), options, SSPRK3_step[T],
                                 useFSAL = false, order = 3.0, adaptive = false)
         of "ralston4":
-            return ODESolver(f, y0, tspan.sorted(), options, RALSTON4_step,
+            return ODESolver(f, y0, tspan.sorted(), options, RALSTON4_step[T],
                                 useFSAL = false, order = 4.0, adaptive = false)
         of "kutta4":
-            return ODESolver(f, y0, tspan.sorted(), options, KUTTA4_step,
+            return ODESolver(f, y0, tspan.sorted(), options, KUTTA4_step[T],
                                 useFSAL = false, order = 4.0, adaptive = false)
         of "vern65":
-            return ODESolver(f, y0, tspan.sorted(), options, VERN65_step,
+            return ODESolver(f, y0, tspan.sorted(), options, VERN65_step[T],
                                 useFSAL = true, order = 6.0, adaptive = true)
         of "tsit54":
-            return ODESolver(f, y0, tspan.sorted(), options, TSIT54_step,
+            return ODESolver(f, y0, tspan.sorted(), options, TSIT54_step[T],
                              useFSAL = true, order = 5.0, adaptive = true)
         else:
             raise newException(ValueError, &"{integrator} is not a valid integrator")

--- a/src/numericalnim/ode.nim
+++ b/src/numericalnim/ode.nim
@@ -24,8 +24,8 @@ template `/.`(d1, d2: float): float =
 template `*.`(d1, d2: float): float =
     d1 * d2
 
-proc size(d: float): int = 1
-proc sum(d: float): float = d
+proc size(d: float): int {.inline.} = 1
+proc sum(d: float): float {.inline.} = d
 
 template commonAdaptiveMethodCode(yNew, error_y: untyped, order: int, body: untyped) =
     while limitCounter < 2:

--- a/src/numericalnim/ode.nim
+++ b/src/numericalnim/ode.nim
@@ -499,7 +499,7 @@ proc ODESolver[T](f: proc(t: float, y: T): T, y0: T, tspan: openArray[float],
                 if error == 0.0:
                     dt *= 5
                 else:
-                    dt = 0.9 * dt * pow(tol/error, 1.0/order)
+                    dt = dt * min(4, max(0.125, 0.9 * pow(1/error, 1/order)))
                 if dt < dtMin:
                     dt = dtMin
                 elif dtMax < dt:
@@ -541,7 +541,7 @@ proc ODESolver[T](f: proc(t: float, y: T): T, y0: T, tspan: openArray[float],
                 if error == 0.0:
                     dt *= 5
                 else:
-                    dt = 0.9 * dt * pow(tol/error, 1.0/order)
+                    dt = dt * min(4, max(0.125, 0.9 * pow(1/error, 1/order)))
                 if dt < dtMin:
                     dt = dtMin
                 elif dtMax < dt:

--- a/src/numericalnim/utils.nim
+++ b/src/numericalnim/utils.nim
@@ -38,11 +38,14 @@ proc `@`*[T](v: Vector[Vector[Vector[T]]]): seq[seq[seq[T]]] {.inline.} =
     for i in 0 ..< v.len:
         result.add(@(v[i]))
 proc toTensor*(v: Vector): Tensor[float] {.inline.} = (@v).toTensor()
-proc`==`*[T](v1, v2: Vector[T]): bool {.inline.} =
+proc `==`*[T](v1, v2: Vector[T]): bool {.inline.} =
     for i in 0 .. v1.components.high:
         if v1[i] != v2[i]:
             return false
     return true
+
+proc size*[T](v: Vector[T]): int = v.components.len
+
 proc `+`*[T](v1, v2: Vector[T]): Vector[T] {.inline.} =
     checkVectorSizes(v1, v2)
     var newComponents = newSeq[T](v1.len)

--- a/tests/test_ode.nim
+++ b/tests/test_ode.nim
@@ -6,9 +6,9 @@ proc f(x: float, y: float): float = -0.1 * y
 proc fVector(x: float, y: Vector[float]): Vector[float] = -0.1 * y
 proc fTensor(x: float, y: Tensor[float]): Tensor[float] = -0.1 * y
 proc correct_answer(x: float): float = exp(-0.1*x)
-let oo = newODEoptions(tol=1e-8, dt=1e-6)
-let ooVector = newODEoptions(tol=1e-8, dt=1e-2)
-let ooTensor = newODEoptions(tol=1e-8, dt=1e-2)
+let oo = newODEoptions(relTol=1e-8, dt=1e-6)
+let ooVector = newODEoptions(relTol=1e-8, dt=1e-2)
+let ooTensor = newODEoptions(relTol=1e-8, dt=1e-2)
 let y0 = 1.0
 let y0Vector = newVector(@[y0, y0, y0])
 let y0Tensor = @[y0, y0, y0].toTensor()


### PR DESCRIPTION
Updated the way the error in the adaptive methods work. Instead of just on `tol` we now have `absTol` and `relTol`. And this has been done with templates inspired by @BarrOff 